### PR TITLE
fix: add price greater than zero validation and fix log typo in CreateProduct

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,0 +1,51 @@
+
+## Day 4 — HTTP Layer, Mappings, and Outbox Pattern
+
+### CreateProductEndpoint.cs — The Front Door
+- MapPost("/") → only POST requests allowed at this route
+- RequireAuthorization → you need a badge (JWT token) to enter, no badge = 401
+- MapToApiVersion(1.0) → this is v1, future versions can be added without breaking this
+- Handle() converts raw JSON into value objects (Name.Of, Price.Of, Stock.Of)
+- Returns 201 Created + a link to where you can find the new product (CreatedAtRoute)
+
+### CreateProductRequest vs CreateProduct command
+- Request = raw data from internet (plain strings and numbers)
+- Command = wrapped in value objects (Name, Price, Stock) — bad data rejected here
+- The endpoint is the translator between the two
+
+### ProductMappings.cs — The Translator
+- Three versions of the same data: domain model → read model → DTO
+- Mapperly generates the mapping code automatically at compile time
+- MapProperty handles value objects (ProductId.Value → plain long)
+- MapperIgnoreSource skips fields that should not be sent to client
+
+### ProductCreated.cs — Two Handlers, One Event
+- Handler 1: Creates ProductView (flat read-optimized summary in the database)
+- Handler 2: Saves event to Outbox table for RabbitMQ delivery
+- Domain event uses primitive types (long, string) not value objects
+  → because other services may not have the same value object classes
+
+### MessagePersistenceService.cs — The Postal System
+- Three delivery types: Outbox (going out), Inbox (coming in), Internal (staying inside)
+- Outbox saves message to DB with status "Stored" first, publishes to RabbitMQ later
+- Background service picks up "Stored" messages and publishes them
+- Distributed lock ensures only ONE server instance publishes each message
+- Inbox checks message ID before processing — prevents duplicate processing
+
+### Why Outbox Pattern Exists
+- Without it: server crashes after save but before publish = event lost forever
+- With it: event saved in same DB transaction as product = guaranteed delivery
+- Database is the safety net
+
+### Full Request Flow — Complete Picture
+1. POST /api/v1/catalogs/products arrives
+2. Authorization badge checked
+3. JSON mapped to CreateProductRequest
+4. Value objects created (Name.Of, Price.Of...)
+5. Command sent via commandBus
+6. Validator runs (FluentValidation)
+7. Handler calls Product.Create() with business rule checks
+8. SaveChangesAsync saves product + Outbox message in ONE transaction
+9. 201 Created returned to client
+10. Background service publishes Outbox message to RabbitMQ
+11. Other services receive and react

--- a/src/Services/Catalogs/FoodDelivery.Services.Catalogs/Products/Features/CreatingProduct/v1/CreateProduct.cs
+++ b/src/Services/Catalogs/FoodDelivery.Services.Catalogs/Products/Features/CreatingProduct/v1/CreateProduct.cs
@@ -46,6 +46,9 @@ public class CreateProductValidation : AbstractValidator<CreateProduct>
         RuleFor(x => x.Id).NotNull();
         RuleFor(x => x.Name).NotNull();
         RuleFor(x => x.Price).NotNull();
+        RuleFor(x => x.Price)
+            .Must(p => p != null && p.Value > 0)
+            .WithMessage("Price must be greater than zero.");
         RuleFor(x => x.Stock).NotNull();
         RuleFor(x => x.Dimensions).NotNull();
         RuleFor(x => x.Size).NotNull();
@@ -79,7 +82,7 @@ public class CreateProductHandler(
             .Include(x => x.Supplier)
             .SingleOrDefaultAsync(x => x.Id == product.Id, cancellationToken: cancellationToken);
 
-        logger.LogInformation("Product a with ID: '{ProductId} created.'", created!.Id);
+        logger.LogInformation("Product with ID: '{ProductId}' created.", created!.Id);
 
         return new CreateProductResult(created.Id);
     }


### PR DESCRIPTION
## What this PR fixes

### Fix 1  Missing price validation:
The CreateProductValidation only checked if Price was not null.
It did not validate that the price value itself was greater than zero
at the FluentValidation layer.

Added explicit validation rule:
Price must be greater than zero
Returns clear error message: "Price must be greater than zero."

### Fix 2  Log message typo:
Fixed typo in CreateProductHandler log message.

Before: "Product a with ID: '{ProductId} created.'"
After:  "Product with ID: '{ProductId}' created."

## Why this matters
 Catches invalid price earlier in the pipeline
Gives cleaner error message to the client
Fixes misleading log output in production