### PR TITLE
test: add Stock value object unit tests

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,0 +1,51 @@
+
+## Day 4 — HTTP Layer, Mappings, and Outbox Pattern
+
+### CreateProductEndpoint.cs — The Front Door
+- MapPost("/") → only POST requests allowed at this route
+- RequireAuthorization → you need a badge (JWT token) to enter, no badge = 401
+- MapToApiVersion(1.0) → this is v1, future versions can be added without breaking this
+- Handle() converts raw JSON into value objects (Name.Of, Price.Of, Stock.Of)
+- Returns 201 Created + a link to where you can find the new product (CreatedAtRoute)
+
+### CreateProductRequest vs CreateProduct command
+- Request = raw data from internet (plain strings and numbers)
+- Command = wrapped in value objects (Name, Price, Stock) — bad data rejected here
+- The endpoint is the translator between the two
+
+### ProductMappings.cs — The Translator
+- Three versions of the same data: domain model → read model → DTO
+- Mapperly generates the mapping code automatically at compile time
+- MapProperty handles value objects (ProductId.Value → plain long)
+- MapperIgnoreSource skips fields that should not be sent to client
+
+### ProductCreated.cs — Two Handlers, One Event
+- Handler 1: Creates ProductView (flat read-optimized summary in the database)
+- Handler 2: Saves event to Outbox table for RabbitMQ delivery
+- Domain event uses primitive types (long, string) not value objects
+  → because other services may not have the same value object classes
+
+### MessagePersistenceService.cs — The Postal System
+- Three delivery types: Outbox (going out), Inbox (coming in), Internal (staying inside)
+- Outbox saves message to DB with status "Stored" first, publishes to RabbitMQ later
+- Background service picks up "Stored" messages and publishes them
+- Distributed lock ensures only ONE server instance publishes each message
+- Inbox checks message ID before processing — prevents duplicate processing
+
+### Why Outbox Pattern Exists
+- Without it: server crashes after save but before publish = event lost forever
+- With it: event saved in same DB transaction as product = guaranteed delivery
+- Database is the safety net
+
+### Full Request Flow — Complete Picture
+1. POST /api/v1/catalogs/products arrives
+2. Authorization badge checked
+3. JSON mapped to CreateProductRequest
+4. Value objects created (Name.Of, Price.Of...)
+5. Command sent via commandBus
+6. Validator runs (FluentValidation)
+7. Handler calls Product.Create() with business rule checks
+8. SaveChangesAsync saves product + Outbox message in ONE transaction
+9. 201 Created returned to client
+10. Background service publishes Outbox message to RabbitMQ
+11. Other services receive and react

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.303",
+    "version": "9.0.115",
     "rollForward": "latestFeature",
     "allowPrerelease": true
   }

--- a/tests/Services/Catalogs/FoodDelivery.Services.Catalogs.UnitTests/Products/ProductsMappingTests.cs
+++ b/tests/Services/Catalogs/FoodDelivery.Services.Catalogs.UnitTests/Products/ProductsMappingTests.cs
@@ -1,3 +1,52 @@
+using FoodDelivery.Services.Catalogs.Products.Exceptions.Domain;
+using FoodDelivery.Services.Catalogs.Products.Models.ValueObjects;
+using FluentAssertions;
+using Xunit;
+
 namespace FoodDelivery.Services.Customers.UnitTests.Products;
 
-public class ProductsMappingTests { }
+public class StockValueObjectTests
+{
+    [Fact]
+    public void Should_Create_Stock_When_All_Values_Are_Valid()
+    {
+        // Arrange & Act
+        var stock = Stock.Of(available: 10, restockThreshold: 5, maxStockThreshold: 100);
+
+        // Assert
+        stock.Available.Should().Be(10);
+        stock.RestockThreshold.Should().Be(5);
+        stock.MaxStockThreshold.Should().Be(100);
+    }
+
+    [Fact]
+    public void Should_Throw_When_Available_Exceeds_MaxStockThreshold()
+    {
+        // Arrange & Act
+        var act = () => Stock.Of(available: 600, restockThreshold: 5, maxStockThreshold: 100);
+
+        // Assert
+        act.Should().Throw<MaxStockThresholdReachedException>()
+            .WithMessage("*max stock threshold*");
+    }
+
+    [Fact]
+    public void Should_Throw_When_Available_Is_Zero()
+    {
+        // Arrange & Act
+        var act = () => Stock.Of(available: 0, restockThreshold: 5, maxStockThreshold: 100);
+
+        // Assert
+        act.Should().Throw<Exception>();
+    }
+
+    [Fact]
+    public void Should_Throw_When_RestockThreshold_Is_Zero()
+    {
+        // Arrange & Act
+        var act = () => Stock.Of(available: 10, restockThreshold: 0, maxStockThreshold: 100);
+
+        // Assert
+        act.Should().Throw<Exception>();
+    }
+}


### PR DESCRIPTION
## What this PR adds

Added first unit tests for the Stock value object in the Catalogs service.

### Tests Added (4 tests)

1. Should_Create_Stock_When_All_Values_Are_Valid
   → Stock.Of(10, 5, 100) creates successfully with correct values

2. Should_Throw_When_Available_Exceeds_MaxStockThreshold
   → Stock.Of(600, 5, 100) throws MaxStockThresholdReachedException

3. Should_Throw_When_Available_Is_Zero
   → Stock.Of(0, 5, 100) throws zero stock not allowed

4. Should_Throw_When_RestockThreshold_Is_Zero
   → Stock.Of(10, 0, 100) throws Zero restock threshold not allowed

### Also Fixed
- global.json SDK version updated from 9.0.303 to 9.0.115
  to match locally installed .NET SDK

### Why Stock
Stock is the most complex value object in the domain 
it owns 3 values and enforces a cross-field business rule
(Available cannot exceed MaxStockThreshold).
It is the highest value target for unit testing.